### PR TITLE
Horizon configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,15 +8,24 @@
     "homepage": "https://github.com/rocketeers-app/rocketeers-laravel",
     "license": "MIT",
     "type": "library",
-    "authors": [{
-        "name": "Mark van Eijk",
-        "email": "mark@vaneijk.co",
-        "role": "Developer"
-    }],
+    "authors": [
+        {
+            "name": "Mark van Eijk",
+            "email": "mark@vaneijk.co",
+            "role": "Developer"
+        },
+        {
+            "name": "Manoj Hortulanus",
+            "email": "manoj@backstagephp.com",
+            "role": "Developer"
+        }
+    ],
     "require": {
         "php": "^7.0|^8.0",
         "illuminate/support": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/auth": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
         "monolog/monolog": "^3.0",
+        "laravel/horizon": ">=5.0",
         "rocketeers-app/rocketeers-api-client": "dev-master"
     },
     "require-dev": {

--- a/src/Facades/RocketeersHorizon.php
+++ b/src/Facades/RocketeersHorizon.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Rocketeers\Laravel\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static void defineAccess(Closure $closure)
+ * @method static bool hasAccess()
+ * @method static bool getDefaultAccess()
+ *
+ * @see \Rocketeers\Laravel\Services\Horizon
+ */
+class RocketeersHorizon extends Facade
+{
+    public static function getFacadeAccessor()
+    {
+        return 'rocketeers.horizon';
+    }
+}

--- a/src/RocketeersHorizonServiceProvider.php
+++ b/src/RocketeersHorizonServiceProvider.php
@@ -2,8 +2,10 @@
 
 namespace Rocketeers\Laravel;
 
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Application;
 use Rocketeers\Laravel\Services\Horizon;
 use Laravel\Horizon\HorizonApplicationServiceProvider;
 use Rocketeers\Laravel\Facades\RocketeersHorizon;
@@ -12,7 +14,25 @@ class RocketeersHorizonServiceProvider extends HorizonApplicationServiceProvider
 {
     public function register()
     {
-        $this->app->singleton('rocketeers.horizon', fn () => new Horizon);
+        $this->app->singleton('rocketeers.horizon', fn() => new Horizon);
+
+        $this->app->booting(function ($app) {
+            /**
+             * @var \Illuminate\Contracts\Config\Repository $config
+             */
+            $config = $app->make(Repository::class);
+
+            $horizonPath = trim($config->get('horizon.path', 'horizon'), '/');
+
+            $paths = $config->get('cors.paths', []);
+
+            if (!in_array($horizonPath, $paths, true)) {
+                $paths[] = $horizonPath;
+                $config->set('cors.paths', $paths);
+            }
+
+            dd($paths);
+        });
     }
 
     protected function gate()

--- a/src/RocketeersHorizonServiceProvider.php
+++ b/src/RocketeersHorizonServiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Rocketeers\Laravel;
+
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Gate;
+use Rocketeers\Laravel\Services\Horizon;
+use Laravel\Horizon\HorizonApplicationServiceProvider;
+use Rocketeers\Laravel\Facades\RocketeersHorizon;
+
+class RocketeersHorizonServiceProvider extends HorizonApplicationServiceProvider
+{
+    public function register()
+    {
+        $this->app->singleton('rocketeers.horizon', fn () => new Horizon);
+    }
+
+    protected function gate()
+    {
+        Gate::define('viewHorizon', function ($user = null) {
+            return RocketeersHorizon::getDefaultAccess() || RocketeersHorizon::hasAccess($user);
+        });
+    }
+}

--- a/src/RocketeersHorizonServiceProvider.php
+++ b/src/RocketeersHorizonServiceProvider.php
@@ -30,8 +30,6 @@ class RocketeersHorizonServiceProvider extends HorizonApplicationServiceProvider
                 $paths[] = $horizonPath;
                 $config->set('cors.paths', $paths);
             }
-
-            dd($paths);
         });
     }
 

--- a/src/RocketeersLoggerServiceProvider.php
+++ b/src/RocketeersLoggerServiceProvider.php
@@ -3,15 +3,17 @@
 namespace Rocketeers\Laravel;
 
 use Exception;
-use Illuminate\Container\Container;
-use Illuminate\Foundation\Application as LaravelApplication;
-use Illuminate\Log\Events\MessageLogged;
+use Monolog\Logger;
 use Illuminate\Log\LogManager;
+use Illuminate\Container\Container;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Log\Events\MessageLogged;
+use Rocketeers\Laravel\Services\Horizon;
 use Laravel\Lumen\Application as LumenApplication;
-use Monolog\Logger;
 use Rocketeers\Laravel\RocketeersEventServiceProvider;
+use Rocketeers\Laravel\RocketeersHorizonServiceProvider;
+use Illuminate\Foundation\Application as LaravelApplication;
 
 class RocketeersLoggerServiceProvider extends ServiceProvider
 {
@@ -21,7 +23,7 @@ class RocketeersLoggerServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->publishes([
-            __DIR__.'/../config/rocketeers.php' => config_path('rocketeers.php'),
+            __DIR__ . '/../config/rocketeers.php' => config_path('rocketeers.php'),
         ], 'config');
     }
 
@@ -30,11 +32,13 @@ class RocketeersLoggerServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $source = realpath($raw = __DIR__.'/../config/rocketeers.php') ?: $raw;
+        $source = realpath($raw = __DIR__ . '/../config/rocketeers.php') ?: $raw;
 
         $this->mergeConfigFrom($source, 'rocketeers');
 
         $this->app->register(RocketeersEventServiceProvider::class);
+
+        $this->app->register(RocketeersHorizonServiceProvider::class);
 
         $this->app->singleton('rocketeers.logger', function ($app) {
             $handler = new RocketeersLoggerHandler($app->make('rocketeers.client'));

--- a/src/Services/Horizon.php
+++ b/src/Services/Horizon.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Rocketeers\Laravel\Services;
+
+use Closure;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Request;
+use Symfony\Component\HttpFoundation\HeaderBag;
+
+class Horizon
+{
+    public null|Closure $hasAccess = null;
+
+    public function defineAccess(Closure $closure): void
+    {
+        $this->hasAccess = $closure;
+    }
+
+    public function hasAccess($user = null): bool
+    {
+        return !is_null($this->hasAccess) ? App::call($this->hasAccess, ['user' => $user]) : false;
+    }
+
+    public function getDefaultAccess(): bool
+    {
+        /**
+         * @var \Illuminate\Http\Request $request
+         */
+        $request = Request::instance();
+
+        /**
+         * @var HeaderBag $headers
+         */
+        $headers = $request->headers;
+
+        if (!$headers->has('Authorization')) {
+            return false;
+        }
+
+        return Request::bearerToken() === Config::get('services.horizon.secret') || Request::bearerToken() === Config::get('rocketeers.api_token');
+    }
+}

--- a/src/Services/Horizon.php
+++ b/src/Services/Horizon.php
@@ -27,7 +27,7 @@ class Horizon
         /**
          * @var \Illuminate\Http\Request $request
          */
-        $request = Request::instance();
+        $request = $this->getRequestInstance();
 
         /**
          * @var HeaderBag $headers
@@ -38,6 +38,11 @@ class Horizon
             return false;
         }
 
-        return Request::bearerToken() === Config::get('services.horizon.secret') || Request::bearerToken() === Config::get('rocketeers.api_token');
+        return $request->bearerToken() === Config::get('services.horizon.secret') || $request->bearerToken() === Config::get('rocketeers.api_token');
+    }
+
+    public function getRequestInstance(): \Illuminate\Http\Request
+    {
+        return Request::instance();
     }
 }


### PR DESCRIPTION
This pull request introduces significant updates to integrate Laravel Horizon into the Rocketeers Laravel package. The changes include adding dependencies, creating a new service provider and facade for Horizon, and implementing access control for Horizon's dashboard. Below are the key changes grouped by theme.

### Dependency Updates
* Added `illuminate/auth` and `laravel/horizon` as required dependencies in `composer.json` to enable Horizon integration.

### New Horizon Integration
* Introduced a new facade `RocketeersHorizon` to provide a static interface for Horizon-related operations.
* Added `RocketeersHorizonServiceProvider`, extending Laravel's `HorizonApplicationServiceProvider`, to register Horizon services, configure CORS paths, and define access control gates.
* Created a new `Horizon` service class to handle access control logic, including token-based authentication for Horizon's dashboard.

### Logger Service Provider Update
* Updated `RocketeersLoggerServiceProvider` to register the new `RocketeersHorizonServiceProvider`, ensuring Horizon services are loaded alongside the logger. [[1]](diffhunk://#diff-30b22dd24d163e1c5b36dfd0eb741775114d164a7b3d09e5ea5df81dfa3a92c3L6-R16) [[2]](diffhunk://#diff-30b22dd24d163e1c5b36dfd0eb741775114d164a7b3d09e5ea5df81dfa3a92c3R41-R42)