### PR TITLE
fix: register rocketeers.client singleton

### DIFF
--- a/src/RocketeersLoggerServiceProvider.php
+++ b/src/RocketeersLoggerServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Log\LogManager;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 use Monolog\Logger;
+use Rocketeers\Rocketeers;
 
 class RocketeersLoggerServiceProvider extends ServiceProvider
 {
@@ -31,6 +32,10 @@ class RocketeersLoggerServiceProvider extends ServiceProvider
         $this->mergeConfigFrom($source, 'rocketeers');
 
         $this->app->register(RocketeersEventServiceProvider::class);
+
+        $this->app->singleton('rocketeers.client', function () {
+            return new Rocketeers(config('rocketeers.api_token'));
+        });
 
         $this->app->singleton('rocketeers.logger', function ($app) {
             $handler = new RocketeersLoggerHandler($app->make('rocketeers.client'));


### PR DESCRIPTION
## Summary
- Register `rocketeers.client` singleton in the service provider
- The logger handler resolves `rocketeers.client` from the container but it was never bound, causing a `BindingResolutionException` at runtime

## Test plan
- [x] Verify `app('rocketeers.client')` resolves to a `Rocketeers\Rocketeers` instance
- [x] Verify error logging via the `rocketeers` log channel works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)